### PR TITLE
Paintings column type rename to category

### DIFF
--- a/app/models/painting.rb
+++ b/app/models/painting.rb
@@ -2,6 +2,6 @@ class Painting < ApplicationRecord
   belongs_to :user
   has_many :bookings
 
-  validates :title, :price_cents_per_day, :width, :height, :type, :location, presence: true
+  validates :title, :price_cents_per_day, :width, :height, :category, :location, presence: true
   validates :width, :height, :price_cents_per_day, numericality: { only_integer: true }
 end

--- a/db/migrate/20210223111821_rename_type_to_category.rb
+++ b/db/migrate/20210223111821_rename_type_to_category.rb
@@ -1,0 +1,5 @@
+class RenameTypeToCategory < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :paintings, :type, :category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_22_165557) do
+ActiveRecord::Schema.define(version: 2021_02_23_111821) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2021_02_22_165557) do
   end
 
   create_table "paintings", force: :cascade do |t|
-    t.string "type"
+    t.string "category"
     t.integer "width"
     t.integer "height"
     t.integer "price_cents_per_day"


### PR DESCRIPTION
Renamed the "type" column on the paintings table to "category" because "type" is reserved under ruby on rails, which prevented us from creating paintings.