### PR TITLE
Fix action link position on paintings show card

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,4 +13,3 @@
 @import "pages/index";@import "pages/index";
 
 @import "bookings/index";
-@import "paintings/index";

--- a/app/assets/stylesheets/paintings/_index.scss
+++ b/app/assets/stylesheets/paintings/_index.scss
@@ -1,1 +1,0 @@
-@import "show";

--- a/app/assets/stylesheets/paintings/_show.scss
+++ b/app/assets/stylesheets/paintings/_show.scss
@@ -1,5 +1,0 @@
-#painting-controls {
-  position: absolute;
-  right: 20px;
-  bottom: 15px;
-}

--- a/app/assets/stylesheets/paintings/_show.scss
+++ b/app/assets/stylesheets/paintings/_show.scss
@@ -1,5 +1,5 @@
 #painting-controls {
   position: absolute;
-  right: 2%;
-  bottom: 6%;
+  right: 20px;
+  bottom: 15px;
 }

--- a/app/views/paintings/show.html.erb
+++ b/app/views/paintings/show.html.erb
@@ -13,17 +13,19 @@
         <li class="list-group-item"><%= "Medium: #{@painting.category}" %></li>
         <li class="list-group-item"><%= "Cost/day: €#{(@painting.price_cents_per_day / 100).to_f}" %></li>
         <li class="list-group-item"><%= "Location: #{@painting.location}" %></li>
+        <% if current_user.id == @painting.user_id %>
+        <li class="list-group-item d-flex justify-content-end">
+          <div>
+            <%= link_to 'Edit', edit_painting_path(@painting), class: 'ml-3 text-warning' %>
+            <%= link_to "Remove", painting_path(@painting),
+                method: :delete,
+                data: { confirm: "Are you sure?" },
+                class: 'ml-3 text-danger'
+            %>
+          </div>
+        </li>
+        <% end %>
       </ul>
-    </div>
-    <div id="painting-controls">
-      <div class="d-flex">
-        <%= link_to 'Edit', edit_painting_path(@painting), class: 'ml-3 text-warning' %>
-        <%= link_to "Remove", painting_path(@painting),
-            method: :delete,
-            data: { confirm: "Are you sure?" },
-            class: 'ml-3 text-danger'
-        %>
-      </div>
     </div>
   </div>
   <%= link_to "Book this painting", new_painting_booking_path(@painting), class: "btn btn-primary my-4" %>


### PR DESCRIPTION
Action links are now a list item so they do not overflow onto other elements, they also only show if painting belongs to the current user.